### PR TITLE
fix(datepicker): keep comp configuration updated (#5383)

### DIFF
--- a/demo/src/app/components/+datepicker/demos/index.ts
+++ b/demo/src/app/components/+datepicker/demos/index.ts
@@ -26,7 +26,7 @@ import {
 
 import { DemoDatePickerAdaptivePositionComponent } from './adaptive-position/adaptive-position';
 import { DemoDatePickerAnimatedComponent } from './animated/animated';
-import { DemoDatepickerDateCustomClassesComponent } from './date-custom-classes/date-custom-classes'
+import { DemoDatepickerDateCustomClassesComponent } from './date-custom-classes/date-custom-classes';
 import { DemoDatePickerSelectWeekComponent } from './select-week/select-week';
 import { DemoDatepickerTriggersCustomComponent } from './triggers-custom/triggers-custom';
 import { DemoDatepickerTriggersManualComponent } from './triggers-manual/triggers-manual';

--- a/src/datepicker/bs-datepicker-input.directive.ts
+++ b/src/datepicker/bs-datepicker-input.directive.ts
@@ -30,6 +30,7 @@ import {
 
 import { BsDatepickerDirective } from './bs-datepicker.component';
 import { BsLocaleService } from './bs-locale.service';
+import { BsDatepickerConfig } from './bs-datepicker.config';
 
 const BS_DATEPICKER_VALUE_ACCESSOR: Provider = {
   provide: NG_VALUE_ACCESSOR,
@@ -68,8 +69,8 @@ export class BsDatepickerInputDirective
               private _elRef: ElementRef,
               private changeDetection: ChangeDetectorRef) {
     // update input value on datepicker value update
-    this._picker.bsValueChange.subscribe((value: Date) => {
-
+    this._picker.config$.subscribe((config: BsDatepickerConfig) => {
+      const value = config.value as Date;
       let preValue = value;
       if (value) {
         const _localeKey = this._localeService.currentLocale;
@@ -82,7 +83,7 @@ export class BsDatepickerInputDirective
         preValue = _locale.preinput(value);
       }
 
-      this._setInputValue(preValue);
+      this._setInputValue(preValue, config.dateInputFormat);
       if (this._value !== preValue) {
         this._value = preValue;
         this._onChange(preValue);
@@ -97,9 +98,10 @@ export class BsDatepickerInputDirective
     });
   }
 
-  _setInputValue(value: Date): void {
+  _setInputValue(value: Date, dateInputFormat?: string): void {
+    const _dateInputFormat = dateInputFormat || this._picker._config.dateInputFormat;
     const initialDate = !value ? ''
-      : formatDate(value, this._picker._config.dateInputFormat, this._localeService.currentLocale);
+      : formatDate(value, _dateInputFormat, this._localeService.currentLocale);
 
     this._renderer.setProperty(this._elRef.nativeElement, 'value', initialDate);
   }

--- a/src/datepicker/bs-datepicker.spec.ts
+++ b/src/datepicker/bs-datepicker.spec.ts
@@ -12,7 +12,7 @@ import { registerEscClick } from '../utils';
 
 @Component({
   selector: 'test-cmp',
-  template: `<input type="text" bsDatepicker [bsConfig]="bsConfig">`
+  template: `<input *ngIf="show" type="text" bsDatepicker [(bsValue)]="date" [bsConfig]="bsConfig">`
 })
 class TestComponent {
   @ViewChild(BsDatepickerDirective, { static: false }) datepicker: BsDatepickerDirective;
@@ -20,6 +20,8 @@ class TestComponent {
     displayMonths: 2,
     selectWeek: true
   };
+  show = true;
+  date = new Date();
 }
 
 type TestFixture = ComponentFixture<TestComponent>;
@@ -127,5 +129,28 @@ describe('datepicker:', () => {
     dispatchKeyboardEvent(document, 'keyup', 'Escape');
 
     expect(spy).toHaveBeenCalled();
+  }));
+
+  it('should keep config in sync', async(() => {
+    const datepicker = showDatepicker(fixture);
+    const datepickerContainerInstance = getDatepickerContainer(datepicker);
+    fixture.componentRef.instance.bsConfig = { dateInputFormat: 'DD/MM/YYYY' };
+    const date = new Date(2019, 1, 24);
+    const expectedResponse = '24/02/2019';
+
+    showDatepicker(fixture);
+    datepickerContainerInstance.valueChange.emit(date);
+    let input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    expect(input.value).toEqual(expectedResponse);
+
+    fixture.componentRef.instance.show = false;
+    fixture.detectChanges();
+    input = fixture.nativeElement.querySelector('input');
+    expect(input).toBeNull();
+
+    fixture.componentRef.instance.show = true;
+    fixture.detectChanges();
+    input = fixture.nativeElement.querySelector('input');
+    expect(input.value).toEqual(expectedResponse);
   }));
 });

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,25 +1,43 @@
 /*tslint:disable:no-invalid-this */
+import { EventEmitter } from '@angular/core';
+import { Subject } from 'rxjs';
+
+type onChangeCallbackType<T> = (value: T, prevValue: T, propertyKey: string) => void;
 /* tslint:disable-next-line: no-any */
-export function OnChange(defaultValue?: any): any {
+type onChangeHandlerType = (target: any, propertyKey: string) => void;
+type callbackType<T> = onChangeCallbackType<T> | EventEmitter<T> | Subject<T> | string;
+
+export function OnChange<T>(callback?: callbackType<T>): onChangeHandlerType {
   const sufix = 'Change';
 
-  /* tslint:disable-next-line: no-any */
-  return function OnChangeHandler(target: any, propertyKey: string): void {
-    const _key = ` __${propertyKey}Value`;
+  function emitValue(_callback: callbackType<T>, value: T, prevValue: T, propertyKey: string): void {
+    if (_callback instanceof EventEmitter) {
+      _callback.emit(value);
+    } else if (_callback instanceof Subject) {
+      _callback.next(value);
+    } else if (_callback instanceof Function) {
+      _callback.call(this, value, prevValue, propertyKey);
+    }
+  }
+
+  return function onChangeHandler(target, propertyKey) {
+    const _key = `__${propertyKey}Value`;
     Object.defineProperty(target, propertyKey, {
-      /* tslint:disable-next-line: no-any */
-      get(): any {
+      get(): T {
         return this[_key];
       },
-      /* tslint:disable-next-line: no-any */
-      set(value: any): void {
+      set(value: T): void {
         const prevValue = this[_key];
         this[_key] = value;
-        if (prevValue !== value && this[propertyKey + sufix]) {
-          this[propertyKey + sufix].emit(value);
+        if (prevValue === value) {
+          return;
         }
+        const _callbackName = typeof callback === 'undefined' ? propertyKey + sufix : callback;
+        const _callback = typeof _callbackName === 'string' ? this[_callbackName] : _callbackName;
+        emitValue.call(this, _callback, value, prevValue, propertyKey);
       }
     });
   };
 }
+
 /* tslint:enable */


### PR DESCRIPTION
In this PR I made component's configuration to be always up to date. 

### Overview
Datepicker configuration composed with 4 parts:
1. _config: BsDatepickerConfig - default configuration 
2. Input bsConfig: Partial<BsDatepickerConfig>  -  user can pass partial configuration, that can overwrite default one
3. Input bsValue: Date - datepicker value and also is part of config (config.value)
4. all other inputs, like: isDisabled, minDate, maxDate... - component's configuration properties, that user can tune separately.

We have to keep in mind, that any value that comes from **Input can be changed any time**.

### Why issue happened
Configuration was recalculated (setConfig) only on ngOnInit() and on show() calls, therefore there are situations when calculated config was out of sync with updated input config properties.

### Solution
I created config$ stream, that listens to every part of component's configuration and recalculates final config if any part updated . This way "_config" always reflects actual configuration state.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [ ] added/updated API documentation.
 - [ ] added/updated demos.
