### PR TITLE
refactor(component-loader): replace ComponentFactoryResolver with createComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="http://valor-software.com/ngx-bootstrap/#/">
 <div align="center">
     <img class="mx-auto center-block d-block" src="https://valor-software.com/ngx-bootstrap/assets/images/logos/ngx-bootstrap-logo.svg" alt="ngx-bootstrap" width="200" height="200" />
-    <h1>ngx-bootstrap w/o angular/animation</h1>
+    <h1>ngx-bootstrap</h1>
 </div>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="http://valor-software.com/ngx-bootstrap/#/">
 <div align="center">
     <img class="mx-auto center-block d-block" src="https://valor-software.com/ngx-bootstrap/assets/images/logos/ngx-bootstrap-logo.svg" alt="ngx-bootstrap" width="200" height="200" />
-    <h1>ngx-bootstrap</h1>
+    <h1>ngx-bootstrap w/o angular/animation</h1>
 </div>
 </a>
 

--- a/src/component-loader/component-loader.class.ts
+++ b/src/component-loader/component-loader.class.ts
@@ -3,11 +3,11 @@
 // todo: add global positioning configuration?
 import {
   ApplicationRef,
-  ComponentFactory,
-  ComponentFactoryResolver,
   ComponentRef,
+  createComponent,
   ElementRef,
   EmbeddedViewRef,
+  EnvironmentInjector,
   EventEmitter,
   Injector,
   Renderer2,
@@ -37,7 +37,7 @@ export class ComponentLoader<T extends object> {
   _inlineViewRef?: EmbeddedViewRef<T>;
 
   private _providers: StaticProvider[] = [];
-  private _componentFactory?: ComponentFactory<T>;
+  private _compType?: Type<T>;
   private _positioningRafId?: number;
   private _contentRef?: ContentRef;
   private _innerComponent?: ComponentRef<T>;
@@ -75,7 +75,7 @@ export class ComponentLoader<T extends object> {
     private _renderer: Renderer2 | undefined,
     private _elementRef: ElementRef | undefined,
     private _injector: Injector,
-    private _componentFactoryResolver: ComponentFactoryResolver,
+    private _environmentInjector: EnvironmentInjector,
     private _applicationRef: ApplicationRef,
     private _posService: PositioningService,
     private _document: Document,
@@ -91,8 +91,7 @@ export class ComponentLoader<T extends object> {
   }
 
   attach(compType: Type<T>): ComponentLoader<T> {
-    this._componentFactory = this._componentFactoryResolver
-      .resolveComponentFactory<T>(compType);
+    this._compType = compType;
 
     return this;
   }
@@ -139,16 +138,20 @@ export class ComponentLoader<T extends object> {
       this.onBeforeShow.emit();
       this._contentRef = this._getContentRef(opts.content, opts.context, opts.initialState);
 
-      const injector = Injector.create({
+      const elementInjector = Injector.create({
         providers: this._providers,
         parent: this._injector
       });
 
-      if (!this._componentFactory) {
+      if (!this._compType) {
         return;
       }
 
-      this._componentRef = this._componentFactory.create(injector, this._contentRef.nodes);
+      this._componentRef = createComponent(this._compType, {
+        environmentInjector: this._environmentInjector,
+        elementInjector,
+        projectableNodes: this._contentRef.nodes
+      });
 
       this._applicationRef.attachView(this._componentRef.hostView);
       // this._componentRef = this._viewContainerRef
@@ -412,16 +415,15 @@ export class ComponentLoader<T extends object> {
     }
 
     if (typeof content === 'function') {
-      const contentCmptFactory = this._componentFactoryResolver.resolveComponentFactory(
-        content
-      );
-
       const modalContentInjector = Injector.create({
         providers: this._providers,
         parent: this._injector
       });
 
-      const componentRef = contentCmptFactory.create(modalContentInjector);
+      const componentRef = createComponent(content, {
+        environmentInjector: this._environmentInjector,
+        elementInjector: modalContentInjector,
+      });
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       Object.assign(componentRef.instance, initialState);

--- a/src/component-loader/component-loader.factory.ts
+++ b/src/component-loader/component-loader.factory.ts
@@ -1,5 +1,5 @@
 import {
-  ApplicationRef, ComponentFactoryResolver, ElementRef, Inject, Injectable, Injector,
+  ApplicationRef, ElementRef, EnvironmentInjector, Inject, Injectable, Injector,
   Renderer2, ViewContainerRef
 } from '@angular/core';
 import { ComponentLoader } from './component-loader.class';
@@ -8,7 +8,7 @@ import { DOCUMENT } from '@angular/common';
 
 @Injectable({providedIn: 'root'})
 export class ComponentLoaderFactory {
-  constructor(private _componentFactoryResolver: ComponentFactoryResolver,
+  constructor(private _environmentInjector: EnvironmentInjector,
               private _injector: Injector,
               private _posService: PositioningService,
               private _applicationRef: ApplicationRef,
@@ -30,7 +30,7 @@ export class ComponentLoaderFactory {
       _renderer,
       _elementRef,
       this._injector,
-      this._componentFactoryResolver,
+      this._environmentInjector,
       this._applicationRef,
       this._posService,
       this._document


### PR DESCRIPTION
## Summary

- `ComponentFactoryResolver` Blocks upgrade to Angular 22rc1. 
- Removes the deprecated `ComponentFactoryResolver` (deprecated in Angular 13, removed in Angular 17+) from `ComponentLoaderFactory` and `ComponentLoader`
- Replaces `ComponentFactory.create()` calls with the modern `createComponent()` function from `@angular/core`
- Injects `EnvironmentInjector` in place of `ComponentFactoryResolver`

## Affected components

All components that use `ComponentLoaderFactory` to dynamically render overlay/popup content are affected by this change:

| Component | File |
|---|---|
| Modal | `src/modal/modal.directive.ts`, `src/modal/bs-modal.service.ts` |
| Tooltip | `src/tooltip/tooltip.directive.ts` |
| Popover | `src/popover/popover.directive.ts` |
| Typeahead | `src/typeahead/typeahead.directive.ts` |
| Dropdown | `src/dropdown/bs-dropdown.directive.ts` |
| Datepicker | `src/datepicker/bs-datepicker.component.ts`, `src/datepicker/bs-daterangepicker.component.ts` |
| Datepicker inline | `src/datepicker/bs-datepicker-inline.component.ts`, `src/datepicker/bs-daterangepicker-inline.component.ts` |

## Test plan

- [x] Modal opens and closes correctly
- [x] Tooltip appears on hover/focus and dismisses
- [x] Popover appears and dismisses
- [x] Typeahead dropdown renders suggestions
- [x] Dropdown opens and closes
- [x] Datepicker and Daterangepicker open, select dates, and close
- [x] Inline datepicker/daterangepicker renders in-place
- [x] All existing unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)