### PR TITLE
fix: avoid NG0956 by tracking @for collections by stable keys

### DIFF
--- a/src/datepicker/testing/bs-datepicker-track-by.spec.ts
+++ b/src/datepicker/testing/bs-datepicker-track-by.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
+
+import { BsDatepickerModule } from '../bs-datepicker.module';
+import { BsDatepickerInlineDirective } from '../bs-datepicker-inline.component';
+import { BsDaterangepickerInlineDirective } from '../bs-daterangepicker-inline.component';
+import { BsDatepickerAbstractComponent } from '../base/bs-datepicker-container';
+import { BsDatepickerViewMode } from '../models';
+
+@Component({
+    selector: 'test-datepicker-cmp',
+    template: `<bs-datepicker-inline></bs-datepicker-inline>`,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false
+})
+class DatepickerTestComponent {
+  @ViewChild(BsDatepickerInlineDirective, { static: false }) datepicker!: BsDatepickerInlineDirective;
+}
+
+@Component({
+    selector: 'test-daterangepicker-cmp',
+    template: `<bs-daterangepicker-inline></bs-daterangepicker-inline>`,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false
+})
+class DaterangepickerTestComponent {
+  @ViewChild(BsDaterangepickerInlineDirective, { static: false }) datepicker!: BsDaterangepickerInlineDirective;
+}
+
+type AnyPickerFixture = ComponentFixture<DatepickerTestComponent | DaterangepickerTestComponent>;
+
+function getContainer(fixture: AnyPickerFixture): BsDatepickerAbstractComponent {
+  return fixture.componentInstance.datepicker[`_datepickerRef`].instance;
+}
+
+function trackingWarnings(warnSpy: jest.SpyInstance): string[] {
+  return warnSpy.mock.calls
+    .map((args: unknown[]) => String(args[0]))
+    .filter((message: string) => message.includes('NG0956'));
+}
+
+function navigateMonths(fixture: AnyPickerFixture, steps: number): void {
+  const container = getContainer(fixture);
+  for (let i = 0; i < steps; i++) {
+    container.navigateTo({ step: { month: 1 } });
+    fixture.detectChanges();
+  }
+}
+
+function switchViewMode(fixture: AnyPickerFixture, viewMode: BsDatepickerViewMode): void {
+  getContainer(fixture).setViewMode(viewMode);
+  fixture.detectChanges();
+}
+
+/**
+ * Regression guard for #6827.
+ *
+ * The calendar view models are rebuilt from scratch on every navigation, so any `@for`
+ * that tracks by object identity destroys and re-creates its entire collection. Angular
+ * reports that as NG0956.
+ *
+ * Note that a single `track` regression can mask the others: while the outer `@for` over
+ * the calendars re-creates `<bs-days-calendar-view>`, the inner loops over weeks and days
+ * run inside a brand-new component instance, so nothing is *re-*created at that level and
+ * they stay silent. All the track expressions therefore have to be checked together, and
+ * both the single-calendar and the two-calendar (range) layouts have to be covered.
+ */
+describe('datepicker: @for track expressions must not re-create collections (NG0956)', () => {
+  let fixture: ComponentFixture<DatepickerTestComponent>;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(waitForAsync(() => TestBed.configureTestingModule({
+    declarations: [DatepickerTestComponent],
+    imports: [BsDatepickerModule]
+  }).compileComponents()));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatepickerTestComponent);
+    fixture.detectChanges();
+    // Spy only after the first render — initial creation can never trip NG0956.
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => warnSpy.mockRestore());
+
+  it('should not warn when navigating the days calendar', () => {
+    navigateMonths(fixture, 3);
+
+    expect(trackingWarnings(warnSpy)).toEqual([]);
+  });
+
+  it('should still render a full day grid after navigating', () => {
+    navigateMonths(fixture, 2);
+
+    const cells = fixture.nativeElement.querySelectorAll('td[role="gridcell"]').length;
+    expect(cells).toBeGreaterThan(0);
+    expect(cells % 7).toBe(0);
+  });
+
+  it('should not warn when navigating the months calendar', () => {
+    switchViewMode(fixture, 'month');
+
+    navigateMonths(fixture, 2);
+
+    expect(trackingWarnings(warnSpy)).toEqual([]);
+  });
+
+  it('should not warn when navigating the years calendar', () => {
+    switchViewMode(fixture, 'year');
+
+    navigateMonths(fixture, 2);
+
+    expect(trackingWarnings(warnSpy)).toEqual([]);
+  });
+
+  it('should not warn when switching back and forth between view modes', () => {
+    for (const viewMode of ['year', 'month', 'day', 'month', 'year'] as const) {
+      switchViewMode(fixture, viewMode);
+    }
+
+    expect(trackingWarnings(warnSpy)).toEqual([]);
+  });
+});
+
+describe('daterangepicker: @for track expressions must not re-create collections (NG0956)', () => {
+  let fixture: ComponentFixture<DaterangepickerTestComponent>;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(waitForAsync(() => TestBed.configureTestingModule({
+    declarations: [DaterangepickerTestComponent],
+    imports: [BsDatepickerModule]
+  }).compileComponents()));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DaterangepickerTestComponent);
+    fixture.detectChanges();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => warnSpy.mockRestore());
+
+  // The range picker renders two side-by-side calendars, which is the "collection of
+  // size 2" the issue reporter saw.
+  it('should not warn when navigating with two calendars displayed', () => {
+    navigateMonths(fixture, 3);
+
+    expect(trackingWarnings(warnSpy)).toEqual([]);
+  });
+
+  it('should keep both calendars rendered after navigating', () => {
+    navigateMonths(fixture, 2);
+
+    expect(fixture.nativeElement.querySelectorAll('bs-days-calendar-view').length).toBe(2);
+  });
+});

--- a/src/datepicker/themes/bs/bs-datepicker-view.html
+++ b/src/datepicker/themes/bs/bs-datepicker-view.html
@@ -8,7 +8,7 @@
           <!--days calendar-->
           @case ('day') {
             <div class="bs-media-container">
-              @for (calendar of daysCalendar$ | async; track calendar) {
+              @for (calendar of daysCalendar$ | async; track $index) {
                 <bs-days-calendar-view
                   [class.bs-datepicker-multiple]="multipleCalendars"
                   [calendar]="calendar"
@@ -34,7 +34,7 @@
           <!--months calendar-->
           @case ('month') {
             <div class="bs-media-container">
-              @for (calendar of monthsCalendar | async; track calendar) {
+              @for (calendar of monthsCalendar | async; track $index) {
                 <bs-month-calendar-view
                   [class.bs-datepicker-multiple]="multipleCalendars"
                   [calendar]="calendar"
@@ -49,7 +49,7 @@
           <!--years calendar-->
           @case ('year') {
             <div class="bs-media-container">
-              @for (calendar of yearsCalendar | async; track calendar) {
+              @for (calendar of yearsCalendar | async; track $index) {
                 <bs-years-calendar-view
                   [class.bs-datepicker-multiple]="multipleCalendars"
                   [calendar]="calendar"

--- a/src/datepicker/themes/bs/bs-days-calendar-view.component.ts
+++ b/src/datepicker/themes/bs/bs-days-calendar-view.component.ts
@@ -44,7 +44,7 @@ import { BsCalendarLayoutComponent } from './bs-calendar-layout.component';
             @if (options && options.showWeekNumbers) {
               <th></th>
             }
-            @for (weekday of calendar.weekdays; track weekday; let i = $index) {
+            @for (weekday of calendar.weekdays; track $index; let i = $index) {
               <th
                 aria-label="weekday">{{ calendar.weekdays[i] }}
               </th>
@@ -52,7 +52,7 @@ import { BsCalendarLayoutComponent } from './bs-calendar-layout.component';
           </tr>
         </thead>
         <tbody>
-          @for (week of calendar.weeks; track week; let i = $index) {
+          @for (week of calendar.weeks; track $index; let i = $index) {
             <tr>
               @if (options && options.showWeekNumbers) {
                 <td class="week" [class.active-week]="isWeekHovered" >
@@ -67,7 +67,7 @@ import { BsCalendarLayoutComponent } from './bs-calendar-layout.component';
                   }
                 </td>
               }
-              @for (day of week.days; track day) {
+              @for (day of week.days; track day.date.getTime()) {
                 <td role="gridcell">
                   <!-- When we want to show tooltips for dates -->
                   @if (!isiOS && isShowTooltip) {

--- a/src/datepicker/themes/bs/bs-months-calendar-view.component.ts
+++ b/src/datepicker/themes/bs/bs-months-calendar-view.component.ts
@@ -24,9 +24,9 @@ import { BsCalendarLayoutComponent } from './bs-calendar-layout.component';
     
       <table role="grid" class="months">
         <tbody>
-          @for (row of calendar?.months; track row) {
+          @for (row of calendar?.months; track $index) {
             <tr>
-              @for (month of row; track month) {
+              @for (month of row; track month.date.getTime()) {
                 <td role="gridcell"
                   (click)="viewMonth(month)"
                   (mouseenter)="hoverMonth(month, true)"

--- a/src/datepicker/themes/bs/bs-years-calendar-view.component.ts
+++ b/src/datepicker/themes/bs/bs-years-calendar-view.component.ts
@@ -25,9 +25,9 @@ import { BsCalendarLayoutComponent } from './bs-calendar-layout.component';
     
       <table role="grid" class="years">
         <tbody>
-          @for (row of calendar?.years; track row) {
+          @for (row of calendar?.years; track $index) {
             <tr>
-              @for (year of row; track year) {
+              @for (year of row; track year.date.getTime()) {
                 <td role="gridcell"
                   (click)="viewYear(year)"
                   (mouseenter)="hoverYear(year, true)"

--- a/src/pagination/pagination.component.html
+++ b/src/pagination/pagination.component.html
@@ -21,7 +21,7 @@
     </li>
   }
 
-  @for (pg of pages; track pg) {
+  @for (pg of pages; track pg.number) {
     <li
       [class.active]="pg.active"
       [class.disabled]="disabled() && !pg.active"

--- a/src/progressbar/progressbar.component.html
+++ b/src/progressbar/progressbar.component.html
@@ -3,7 +3,7 @@
     <ng-content></ng-content>
   </bar>
 } @else {
-  @for (item of _values(); track item) {
+  @for (item of _values(); track $index) {
     <bar
     [type]="item.type" [value]="item.value" [max]="item.max || max()" [animate]="animate()" [striped]="striped()">{{ item.label }}</bar>
   }

--- a/src/sortable/sortable.component.ts
+++ b/src/sortable/sortable.component.ts
@@ -31,7 +31,7 @@ import { NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
       (dragenter)="cancelEvent($event)"
     >{{placeholderItem()}}</div>
   }
-  @for (item of items; track item; let i = $index) {
+  @for (item of items; track $index; let i = $index) {
     <div
       [ngClass]="[ itemClass(), i === activeItem ? itemActiveClass() : '' ]"
       [ngStyle]="getItemStyle(i === activeItem)"

--- a/src/typeahead/typeahead-container.component.html
+++ b/src/typeahead/typeahead-container.component.html
@@ -15,7 +15,7 @@
 
 <!-- Bootstrap 4 options list template -->
 <ng-template #bs4Template>
-  @for (match of matches; track match; let i = $index) {
+  @for (match of matches; track $index; let i = $index) {
     @if (match.isHeader()) {
       <h6 class="dropdown-header">{{ match }}</h6>
     }


### PR DESCRIPTION
Fixes #6827 — the datepicker logs `NG0956` on every month/year navigation, and the same root cause exists in four other components.

## Root cause

The calendar view models are rebuilt from scratch on every navigation, so `@for` blocks that track by **object identity** destroy and re-create their entire collection. Beyond the console warning, this throws away the whole calendar DOM (nodes, directives, child components) on each arrow click.

Angular gates the warning behind `wasReCreated() && isViewExpensiveToRecreate()` — it only fires when *every* item is recreated **and** the per-item view is non-trivial.

**One `track` regression can mask the others.** While the outer loop over `daysCalendar$` re-creates `<bs-days-calendar-view>`, the inner loops over weeks and days run inside a brand-new component instance — nothing is *re*-created at that level, so they stay silent. Fixing only the outer loop (as suggested in the issue) surfaces fresh NG0956 warnings for weeks and days. All the datepicker track expressions therefore had to move together.

## Changes

| Component | Change |
| --- | --- |
| datepicker | 3× calendars → `$index`; weekday headers, week rows → `$index`; day cells → `day.date.getTime()`; month/year grid rows → `$index`; month/year cells → `.date.getTime()` |
| pagination | `track pg` → `track pg.number` |
| typeahead | `track match` → `track $index` |
| progressbar | `track item` → `track $index` |
| sortable | `track item` → `track $index` |

Structural positions track by `$index` since the grid shape is fixed; cells track by date so a day that survives a navigation keeps its DOM node.

## Deliberately not changed: carousel, rating, tabs

These were checked and are **already correct** — they track stable object instances, which is exactly what `track item` is for. Changing them would be churn, and for tabs a small regression, since identity tracking currently lets Angular *move* a tab's DOM when tabs reorder.

Carousel is the instructive case: `indicatorsSlides()` returns a **brand-new array on every change-detection cycle**, so an "array is rebuilt ⇒ broken" heuristic flags it as the worst offender on the list. But `@for` keys on elements, and those are the same `SlideComponent` instances — zero warnings across auto-advance plus forced slide changes.

## Verification

Each fix was reproduced **before** and confirmed clean **after**, in a dev-mode build (`nx serve ngx-bootstrap-docs --configuration development`, which is required — the default serve config is optimized and strips `ngDevMode`, so no Angular dev warning can ever fire there):

| Component | Interaction | Before | After |
| --- | --- | --- | --- |
| datepicker | month arrow | `NG0956` size 1 | none |
| daterangepicker | month arrow | `NG0956` size 2 | none |
| pagination | page click | `NG0956` size 5/7/9 | none |
| typeahead | keystroke with equal match count | `NG0956` size 1 | none |
| progressbar | Randomize (stacked) | `NG0956` size 3 | none |
| sortable | external `writeValue` with identical data | `NG0956` size 4 | none |

Additional checks:

- **pagination keys are collision-free**, including the `...` entries, which use `startPage - 1` / `endPage + 1` and so cannot duplicate a page number. Confirmed live by toggling the rotate demo off to force both-sided ellipsis (`...:5, 6:6 … 10:10, ...:11`) — no `NG0955`.
- **typeahead uses `$index` rather than a value key on purpose**: headers and items share the collection (`match.isHeader()`), so a value key could produce duplicate keys. Grouped rendering is covered by the existing `grouped matches` specs.
- **sortable uses `$index` rather than `item.id` on purpose**: `id` survives reordering, but `onDrop` accepts items dragged in from other zones carrying their own ids, which could collide. Drag reordering was already correct and still renders in the right order after the change.

## Tests

Adds `src/datepicker/testing/bs-datepicker-track-by.spec.ts` — 7 specs covering the days/months/years views, view-mode switching, and the two-calendar range picker. **The spec fails without the template changes** (4 failures carrying the verbatim NG0956 text), so it is a real regression guard.

`nx run-many --target=test --projects=datepicker,pagination,typeahead,progressbar,sortable` → 198 passing, unchanged from baseline. Builds and lint clean.

## Note for maintainers

The `$index` choices silence the warning and stop the DOM churn, but they don't give cross-update view reuse. Getting that in typeahead and sortable would mean adding a stable unique id at the source — a larger change, deliberately out of scope here.

---

# PR Checklist

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [ ] added/updated API documentation. — n/a, no public API change
 - [ ] added/updated demos. — n/a, no new feature; existing demos were used to reproduce and verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
