### PR TITLE
fix(timepicker): use a supported Bootstrap meridian button style

### DIFF
--- a/src/timepicker/timepicker.component.html
+++ b/src/timepicker/timepicker.component.html
@@ -106,7 +106,7 @@
     <!-- meridian -->
     @if (showMeridian()) {
       <td>
-        <button type="button" class="btn btn-default text-center"
+        <button type="button" class="btn btn-secondary text-center"
                 [disabled]="!isEditable || !canToggleMeridian"
                 [class.disabled]="!isEditable || !canToggleMeridian"
                 (click)="toggleMeridian()"


### PR DESCRIPTION
The AM/PM button uses `btn-default`, which Bootstrap 4 and 5 do not define. Switch it to `btn-secondary`, as suggested in the issue, so the button gets its background, border, hover and focus styles.

Fixes #6830.

Validation:

- `npm test -- --parallel=2 --runInBand`: 1,548 passed, 137 skipped across 24 projects.
- `npx nx build timepicker --configuration=production`: passed.
- `npm run lint -- --parallel=2`: passed for all 46 projects.
- Checked the template's button markup in Chrome with the bundled Bootstrap 4.5.3 and 5.2.3 stylesheets. Background, border, hover and focus styles now apply in both versions.

PR checklist:

- [x] Read and followed the contributing guide.
- [x] Built and tested locally.
- [x] Ran the existing Timepicker tests and checked the changed styling in Chrome.
- [x] No API documentation or demo changes needed.
