### PR TITLE
fix(datepicker): emit null instead of undefined when the input is cleared

### DIFF
--- a/src/datepicker/bs-datepicker-input.directive.ts
+++ b/src/datepicker/bs-datepicker-input.directive.ts
@@ -75,7 +75,7 @@ export class BsDatepickerInputDirective implements ControlValueAccessor, Validat
   onChange(event: Event) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.writeValue((event.target as any).value);
-    this._onChange(this._value);
+    this._onChange(this._value ?? null);
     if (this._picker._config.returnFocusToInput) {
       this._renderer.selectRootElement(this._elRef.nativeElement).focus();
     }
@@ -102,7 +102,7 @@ export class BsDatepickerInputDirective implements ControlValueAccessor, Validat
       this._setInputValue(value);
       if (this._value !== value) {
         this._value = value;
-        this._onChange(value);
+        this._onChange(value ?? null);
         this._onTouched();
       }
       this.changeDetection.markForCheck();

--- a/src/datepicker/bs-daterangepicker-input.directive.ts
+++ b/src/datepicker/bs-daterangepicker-input.directive.ts
@@ -82,7 +82,7 @@ export class BsDaterangepickerInputDirective
       this._setInputValue(value);
       if (this._value !== value) {
         this._value = value;
-        this._onChange(value);
+        this._onChange(value ?? null);
         this._onTouched();
       }
       this.changeDetection.markForCheck();
@@ -99,7 +99,7 @@ export class BsDaterangepickerInputDirective
         this._setInputValue(value);
         if (this._value !== value) {
           this._value = value;
-          this._onChange(value);
+          this._onChange(value ?? null);
           this._onTouched();
         }
         this.changeDetection.markForCheck();
@@ -149,7 +149,7 @@ export class BsDaterangepickerInputDirective
   onChange(event: Event) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.writeValue((event.target as any).value);
-    this._onChange(this._value);
+    this._onChange(this._value ?? null);
     if (this._picker._config.returnFocusToInput) {
       this._renderer.selectRootElement(this._elRef.nativeElement).focus();
     }

--- a/src/datepicker/testing/bs-datepicker-input.spec.ts
+++ b/src/datepicker/testing/bs-datepicker-input.spec.ts
@@ -1,0 +1,155 @@
+import { ChangeDetectionStrategy, Component, signal, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { form, FormField } from '@angular/forms/signals';
+import { By } from '@angular/platform-browser';
+
+import { BsDatepickerDirective } from '../bs-datepicker.component';
+import { BsDatepickerModule } from '../bs-datepicker.module';
+import { BsDaterangepickerDirective } from '../bs-daterangepicker.component';
+
+@Component({
+    selector: 'test-datepicker-reactive-forms',
+    template: `<input type="text" bsDatepicker [formControl]="control">`,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false
+})
+class DatepickerReactiveFormsTestComponent {
+  @ViewChild(BsDatepickerDirective, { static: false }) datepicker: BsDatepickerDirective;
+  control = new FormControl<Date | null>(new Date(2024, 0, 15));
+}
+
+@Component({
+    selector: 'test-daterangepicker-reactive-forms',
+    template: `<input type="text" bsDaterangepicker [formControl]="control">`,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false
+})
+class DaterangepickerReactiveFormsTestComponent {
+  @ViewChild(BsDaterangepickerDirective, { static: false }) daterangepicker: BsDaterangepickerDirective;
+  control = new FormControl<Date[] | null>([new Date(2024, 0, 10), new Date(2024, 0, 20)]);
+}
+
+@Component({
+    selector: 'test-datepicker-signal-forms',
+    template: `<input type="text" bsDatepicker [formField]="myForm.myDate">`,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false
+})
+class DatepickerSignalFormsTestComponent {
+  @ViewChild(BsDatepickerDirective, { static: false }) datepicker: BsDatepickerDirective;
+  myModel = signal({ myDate: new Date(2024, 0, 15) as Date | null });
+  myForm = form(this.myModel);
+}
+
+describe('datepicker input: reactive forms', () => {
+  let fixture: ComponentFixture<DatepickerReactiveFormsTestComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DatepickerReactiveFormsTestComponent],
+      imports: [BsDatepickerModule, ReactiveFormsModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatepickerReactiveFormsTestComponent);
+    fixture.detectChanges();
+  });
+
+  it('emits null, not undefined, when the native input is cleared', () => {
+    const input = fixture.debugElement.query(By.css('input[bsDatepicker]')).nativeElement as HTMLInputElement;
+
+    input.value = '';
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.control.value).toBeNull();
+  });
+
+  it('emits null, not undefined, when bsValue is cleared from the picker', () => {
+    const datepicker = fixture.componentInstance.datepicker;
+
+    datepicker.bsValue = undefined;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.control.value).toBeNull();
+  });
+});
+
+describe('daterangepicker input: reactive forms', () => {
+  let fixture: ComponentFixture<DaterangepickerReactiveFormsTestComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DaterangepickerReactiveFormsTestComponent],
+      imports: [BsDatepickerModule, ReactiveFormsModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DaterangepickerReactiveFormsTestComponent);
+    fixture.detectChanges();
+  });
+
+  it('emits null, not undefined, when the native input is cleared', () => {
+    const input = fixture.debugElement.query(By.css('input[bsDaterangepicker]')).nativeElement as HTMLInputElement;
+
+    input.value = '';
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.control.value).toBeNull();
+  });
+
+  it('emits null, not undefined, when bsValue is cleared from the picker', () => {
+    const daterangepicker = fixture.componentInstance.daterangepicker;
+
+    daterangepicker.bsValue = undefined;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.control.value).toBeNull();
+  });
+});
+
+describe('datepicker input: signal forms', () => {
+  let fixture: ComponentFixture<DatepickerSignalFormsTestComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [DatepickerSignalFormsTestComponent],
+      imports: [BsDatepickerModule, FormField]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatepickerSignalFormsTestComponent);
+    fixture.detectChanges();
+  });
+
+  it('does not throw and sets the field to null when the input is cleared', () => {
+    const input = fixture.debugElement.query(By.css('input[bsDatepicker]')).nativeElement as HTMLInputElement;
+
+    expect(() => {
+      input.value = '';
+      input.dispatchEvent(new Event('change'));
+      fixture.detectChanges();
+    }).not.toThrow();
+
+    expect(fixture.componentInstance.myModel().myDate).toBeNull();
+  });
+
+  it('keeps the field alive so a later date still reaches the model', () => {
+    const input = fixture.debugElement.query(By.css('input[bsDatepicker]')).nativeElement as HTMLInputElement;
+
+    input.value = '';
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const nextDate = new Date(2024, 1, 10);
+    fixture.componentInstance.datepicker.bsValue = nextDate;
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.myModel().myDate?.getTime()).toEqual(nextDate.getTime());
+  });
+});


### PR DESCRIPTION
# PR Checklist
Before creating new PR, please take a look at checklist below to make sure that you've done everything that needs to be done before we can merge it.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/valor-software/ngx-bootstrap/blob/development/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated tests.
 - [x] N/A - no public API changes, so no API documentation updates needed.
 - [x] N/A - no new/changed demos needed; existing reactive-forms and signal-forms usage is unaffected other than the cleared-value type.

## Root cause

`BsDatepickerInputDirective` and `BsDaterangepickerInputDirective` call their registered
`onChange` (the value accessor callback) with `undefined` whenever the input is cleared -
either by typing/deleting the text and blurring, or via the picker's own clear action, which
routes through the same `bsValueChange` subscription.

Angular's new Signal Forms (`@angular/forms/signals`) treats a model property that is
explicitly set to `undefined` as "this field no longer exists" and deletes the corresponding
`FieldNode` (`FieldNodeStructure.computeChildrenMap`). Once that happens, any further access to
the field - including `FormField`'s own `state` computed (`this.field()()`) - throws:

```
TypeError: this.field(...) is not a function
```

...and the field can never be updated again, exactly as reported in #6832.

## Change

Emit `null` instead of `undefined` from the CVA `onChange` callback whenever the datepicker or
daterangepicker input is cleared (both the native `change` event path and the picker-driven
`bsValueChange` path, for both directives). `null` is the conventional "empty" sentinel already
used by `FormControl`'s own default, by this library's own timepicker (`onChange(null)` on an
invalid/empty entry), and by Angular Material's datepicker. Internal state (`_value`, the public
`bsValue` input, `writeValue`, `validate`) is unchanged; only the value handed to the form is
normalized at the point it's emitted.

Angular/components applied the identical fix for the same Signal Forms failure mode in
[angular/components#33708](https://github.com/angular/components/pull/33708) (chip listbox
deselection).

## Tests

Added `src/datepicker/testing/bs-datepicker-input.spec.ts` covering both directives:

- Reactive forms: clearing the native input, and clearing via `bsValue` (the picker's own clear
  path), both now leave `control.value` as `null` rather than `undefined`, for `bsDatepicker` and
  `bsDaterangepicker`.
- Signal forms: binding `[formField]` to a `bsDatepicker` input and clearing it no longer throws
  `this.field(...) is not a function`, the field's model value becomes `null`, and the field stays
  alive so a subsequently selected date still reaches the model.

All new specs fail against the current `development` code (reproducing #6832, including the
exact error message) and pass with this change.

Validation:

- `npx nx test datepicker`: 57 passed, 2 skipped.
- `npm test -- --parallel=2 --runInBand`: all 24 projects passed.
- `npx nx lint datepicker` and `npm run lint -- --parallel=2`: all 46 projects passed, 0 errors
  (pre-existing, unrelated warnings only).
- `npx nx build datepicker --configuration=production`: passed.

## Behavioral note

Consumers reading the cleared value from `ngModel`/`FormControl`/`[formField]` now receive
`null` instead of `undefined`. This only affects the "cleared" case; a date value is unaffected.

Fixes #6832
